### PR TITLE
Fixed some typos, use of RFC 2119 and links

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 GA4GH Variation Representation Specification
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-The Variation Representation Specification (VR-Spec) is standard
+The Variation Representation Specification (VR-Spec) is a standard
 developed by the Global Alliance for Genomic Health to facilitate and
 improve sharing of genetic information.  The Specification consists of
 a JSON Schema for representing many classes of genetic variation,

--- a/docs/source/specification/terms_and_model/index.rst
+++ b/docs/source/specification/terms_and_model/index.rst
@@ -22,7 +22,7 @@ with genes.
 translating precise biological definitions into data structures that
 can be used by implementers.** This translation should result in a
 representation of information that is consistent with conventional
-biological understanding, and, ideally, be able to accommodate future
+biological understanding and, ideally, be able to accommodate future
 data as well. The resulting *computational representation* of
 information should also be cognizant of computational performance, the
 minimization of opportunities for misunderstanding, and ease of
@@ -62,12 +62,12 @@ Id
 * This specification RECOMMENDS using :ref:`Computed Identifiers <generating-computed-identifiers>` as ids.
 * A `FHIR Id`_, which is limited to 64 characters from a restricted character set, may be used as a
   VR Id.
-* Ids must correspond 1:1 to object instances: An id refers to exactly one object, and an object has
+* Ids MUST correspond 1:1 to object instances: An id refers to exactly one object, and an object has
   only one id. Therefore, equivalence of objects implies equivalence of ids, and vice versa.
 * Implementations MAY change ids at any time. Therefore, receiving systems SHOULD
   NOT persist Ids from remote sources.
-* Ids are not locatable references. An Id may not be used to retrieve objects from remote
-  databases. Instead, Identifiers should be used for retrieval.
+* Ids are not locatable references. An Id MAY NOT be used to retrieve objects from remote
+  databases. Instead, Identifiers SHOULD be used for retrieval.
 * The VR specification requires a canonical ordering (sorting) of Ids. Sorting a list of Ids MUST be
   performed using the C locale or, equivalently, by first encoding Ids as ASCII.
 

--- a/docs/source/specification/terms_and_model/interval.rst
+++ b/docs/source/specification/terms_and_model/interval.rst
@@ -60,4 +60,4 @@ Interval
 * See `Interbase Interval tests`_ in the VR-python repo for a diagram and examples.
 
 .. _will need to convert: https://www.biostars.org/p/84686/
-.. _Interbase Interval tests: https://github.com/ga4gh/vr-python/blob/master/notebooks/appendices/Interbase%20Interval%20tests.ipynb
+.. _Interbase Interval tests: https://github.com/ga4gh/vr-python/blob/master/notebooks/archive/Interbase%20Interval%20tests.ipynb

--- a/schema/vr.json
+++ b/schema/vr.json
@@ -34,7 +34,7 @@
          "type": "string"
       },
       "Interval": {
-         "description": "A Interval represents a span of sequence.  Positions are always represented by contiguous spans using interbase coordinates.\nThis definition of Interval is intended to be compatible with that in Sequence Ontolgy ([SO:0000001](http://www.sequenceontology.org/browser/current_svn/term/SO:0000001)), with the exception that the GA4GH VR Interval may be zero-width. The SO definition is for an \"extent greater than zero\".",
+         "description": "An Interval represents a span of sequence. Positions are always represented by contiguous spans using interbase coordinates.\nThis definition of Interval is intended to be compatible with that in Sequence Ontology ([SO:0000001](http://www.sequenceontology.org/browser/current_svn/term/SO:0000001)), with the exception that the GA4GH VR Interval may be zero-width. The SO definition is for an \"extent greater than zero\".",
          "discriminator": {
             "propertyName": "type"
          },

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -93,12 +93,12 @@ definitions:
 
   Interval:
     description: >-
-      A Interval represents a span of sequence.  Positions are
+      An Interval represents a span of sequence. Positions are
       always represented by contiguous spans using interbase
       coordinates.
 
       This definition of Interval is intended to be compatible with that
-      in Sequence Ontolgy
+      in Sequence Ontology
       ([SO:0000001](http://www.sequenceontology.org/browser/current_svn/term/SO:0000001)),
       with the exception that the GA4GH VR Interval may be
       zero-width. The SO definition is for an "extent greater than


### PR DESCRIPTION
Some typos fixed, and added use of RFC 2119 in a couple of places. The link to the `Interbase Interval Tests` is now fixed, but it points to an archived file; it should be decided whether to keep it.

In addition to these small changes, I have some suggestions or questions from the [terms and model index page](https://vr-spec.readthedocs.io/en/latest/specification/terms_and_model/index.html):

* Receiving systems SHOULD NOT persist Ids from remote sources. Instead, Identifiers (below) SHOULD be used for communication between systems. -> MUST (NOT) instead of SHOULD (NOT)?
* Use of 'MUST' instead of 'SHALL' could remove the ambiguity that word has (can be a suggestion or a command)