### PR TITLE
#145 sync'd vr.yaml/json with info model tables. converted to list-tables.…

### DIFF
--- a/docs/source/appendices/future_plans.rst
+++ b/docs/source/appendices/future_plans.rst
@@ -70,13 +70,28 @@ region (the *outer* SimpleInterval) and required included region (the
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
+   :widths: auto
 
-   type, string, required, Interval type; must be set to 'NestedInterval'
-   inner, :ref:`SimpleInterval`, required, known interval
-   outer, :ref:`SimpleInterval`, required, potential interval
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - Interval type; must be set to '**NestedInterval**'
+   * - inner
+     - :ref:`SimpleInterval`
+     - 1..1
+     - known interval
+   * - outer
+     - :ref:`SimpleInterval`
+     - 1..1
+     - potential interval
 
 **Implementation guidance**
 
@@ -136,13 +151,32 @@ Ensembl, HGNC, or other public trusted authority.
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
+   :widths: auto
 
-   id, :ref:`Id`, optional, Location id; must be unique within
-   document type, string, required, Location type; must be set to
-   'GeneLocation' gene_id, :ref:`Id`, required, CURIE-formatted gene identifier using NCBI numeric gene id.
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the GeneLocation.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Location Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Location type; must be set to '**GeneLocation**'
+   * - gene_id
+     - :ref:`CURIE <id>`
+     - 1..1
+     - CURIE-formatted gene identifier using NCBI numeric gene id.
 
 **Notes**
 
@@ -163,7 +197,7 @@ State Classes
 @@@@@@@@@@@@@
 
 Additional :ref:`State` concepts that are being planned for future
-consideration in the specification. 
+consideration in the specification.
 
 
 .. _planned-cnvstate:
@@ -187,15 +221,32 @@ Under development.
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
+   :widths: auto
 
-   id, :ref:`Id`, optional, State id; must be unique within document 
-   type, string, required, State type; must be set to 'CNVState'
-   location, :ref:`Location`, the Location of the copy (`null` if unknown)
-   min_copies, int, required, The minimum number of copies
-   max_copies, int, required, The maximum number of copies
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - State type; must be set to '**CNVState**'
+   * - location
+     - :ref:`Location`
+     - 1..1
+     - the Location of the copy ('**null**' if unknown)
+   * - min_copies
+     - int
+     - 1..1
+     - The minimum number of copies
+   * - max_copies
+     - int
+     - 1..1
+     - The maximum number of copies
 
 
 .. _planned-variation:
@@ -222,24 +273,47 @@ co-occur on the same reference sequence.
 
 **Information model**
 
-+---------------+-----------------+----------+---------------------------------------------------------------+
-| Field         | Type            | Label    | Description                                                   |
-+===============+=================+==========+===============================================================+
-| id            | :ref:`Id`       | optional | Variation Id; must be unique within document                  |
-+---------------+-----------------+----------+---------------------------------------------------------------+
-| type          | string          | required |Variation type; must be set to 'Haplotype'                     |
-+---------------+-----------------+----------+---------------------------------------------------------------+
-| location      | :ref:`Location` | required | Where Haplotype is located                                    |
-+---------------+-----------------+----------+---------------------------------------------------------------+
-| completeness  | enum            | required | Declaration of completeness of the Haplotype definition.      |
-|               |                 |          | Values are:                                                   |
-|               |                 |          |                                                               |
-|               |                 |          | * UNKNOWN: Other in-phase Alleles may exist.                  |
-|               |                 |          | * PARTIAL: Other in-phase Alleles exist but are unspecified.  |
-|               |                 |          | * COMPLETE: The Haplotype declares a complete set of Alleles. |
-+---------------+-----------------+----------+---------------------------------------------------------------+
-| alleles       | :ref:`Id[] <Id>`| required | List of Alleles that comprise this Haplotype                  |
-+---------------+-----------------+----------+---------------------------------------------------------------+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the Haplotype.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Variation Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Variation type; must be set to '**Haplotype**'
+   * - location
+     - :ref:`Location`
+     - 1..1
+     - Where Haplotype is located
+   * - completeness
+     - enum
+     - 1..1
+     - Declaration of completeness of the Haplotype definition.
+       Values are:
+
+       * UNKNOWN: Other in-phase Alleles may exist.
+       * PARTIAL: Other in-phase Alleles exist but are unspecified.
+       * COMPLETE: The Haplotype declares a complete set of Alleles.
+
+   * - alleles
+     - :ref:`CURIE[] <id>`
+     - 2..*
+     - List of Alleles that comprise this Haplotype
+
 
 **Implementation guidance**
 
@@ -255,7 +329,7 @@ co-occur on the same reference sequence.
   deletions by other “upstream” Alleles within the Haplotype.
 * When reporting an Haplotype, completeness MUST be set according to
   these criteria:
-  
+
   * "COMPLETE" only if the entire reference sequence was assayed and
     all in-phase Alleles are reported in this Haplotype.
   * "PARTIAL" only if the entire reference sequence was assayed,
@@ -280,7 +354,7 @@ co-occur on the same reference sequence.
   instances of covalently bonded sequences.)
 * Haplotypes are often given names, such as ApoE3 or A*33:01 for
   convenience.
-  
+
    * Examples: `A*33:01:01 (IMGT/HLA)
      <https://www.ebi.ac.uk/cgi-bin/ipd/imgt/hla/get_allele_hgvs.cgi?A*33:01:01>`__
 * When used to report Haplotypes, the completeness property enables
@@ -328,21 +402,42 @@ A list of Haplotypes.
 
 **Information model**
 
-+---------------+------------------+----------+---------------------------------------------------------------------+
-| Field         | Type             | Label    | Description                                                         |
-+===============+==================+==========+=====================================================================+
-| id            | :ref:`Id`        | optional | Variation Id; must be unique within document                        |
-+---------------+------------------+----------+---------------------------------------------------------------------+
-| type          | string           | required | Variation type; must be set to 'Genotype'                           |
-+---------------+------------------+----------+---------------------------------------------------------------------+
-| completeness  | enum             | required | Declaration of completeness of the Genotype definition. Values are: |
-|               |                  |          |                                                                     |
-|               |                  |          | * UNKNOWN: Other Haplotypes may exist.                              |
-|               |                  |          | * PARTIAL: Other Haplotypes exist but are unspecified.              |
-|               |                  |          | * COMPLETE: The Genotype declares a complete set of Haplotypes.     |
-+---------------+------------------+----------+---------------------------------------------------------------------+
-| haplotypes    | :ref:`Id[] <Id>` | required | List of Haplotypes; length must agree with ploidy of genomic region |
-+---------------+------------------+----------+---------------------------------------------------------------------+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the Genotype.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Variation Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Variation type; must be set to '**Genotype**'
+   * - completeness
+     - enum
+     - 1..1
+     - Declaration of completeness of the Haplotype definition.
+       Values are:
+
+       * UNKNOWN: Other Haplotypes may exist.
+       * PARTIAL: Other Haplotypes exist but are unspecified.
+       * COMPLETE: The Genotype declares a complete set of Haplotypes.
+
+   * - haplotypes
+     - :ref:`CURIE[] <id>`
+     - 2..*
+     - List of Haplotypes; length must agree with ploidy of genomic region
 
 **Implementation guidance**
 
@@ -438,7 +533,7 @@ terminology, if any).
 
 **Information model**
 
-Under consideration. See https://github.com/ga4gh/vr-spec/issues/28. 
+Under consideration. See https://github.com/ga4gh/vr-spec/issues/28.
 
 **Examples**
 

--- a/docs/source/impl-guide/computed_identifier.rst
+++ b/docs/source/impl-guide/computed_identifier.rst
@@ -68,7 +68,7 @@ Implementations MUST adhere to the following requirements:
 * VR Computed Identifiers are defined only when all nested objects are
   identified with ``ga4gh`` identifiers.  Generating VR identifiers
   using objects referenced within any other namespace is not compliant
-  with this specification. 
+  with this specification.
 
 .. important:: The above requirement means that *sequences must be
                identified with GA4GH computed identifiers* based on
@@ -93,7 +93,7 @@ compliance.
                serialization or other serialization forms.  Although
                Digest Serialization and JSON serialization appear
                similar, they are NOT interchangeable and will generate
-               different GA4GH Digests.  
+               different GA4GH Digests.
 
 Although several proposals exist for serializing arbitrary data in a
 consistent manner ([Gibson]_, [OLPC]_, [JCS]_), none have been
@@ -175,7 +175,7 @@ For comparison, here is one of many possible JSON serializations of the same obj
       },
       "type": "Allele"
     }
-    
+
 
 
 .. _truncated-digest:
@@ -203,11 +203,11 @@ three steps:
 .. code-block:: python
 
    >>> import base64, hashlib
-   >>> def sha512t24u(blob): 
-           digest = hashlib.sha512(blob).digest() 
-           tdigest = digest[:24] 
-           tdigest_b64u = base64.urlsafe_b64encode(tdigest).decode("ASCII") 
-           return tdigest_b64u 
+   >>> def sha512t24u(blob):
+           digest = hashlib.sha512(blob).digest()
+           tdigest = digest[:24]
+           tdigest_b64u = base64.urlsafe_b64encode(tdigest).decode("ASCII")
+           return tdigest_b64u
    >>> sha512t24u(b"ACGT")
    'aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2'
 
@@ -219,7 +219,7 @@ Identifier Construction
 
 
 The final step of generating a computed identifier for a VR object is
-to generate a `W3C CURIE <curie-spec>`_ formatted identifier, which
+to generate a `W3C CURIE <https://www.w3.org/TR/curie/>`__ formatted identifier, which
 has the form::
 
     prefix ":" reference
@@ -247,11 +247,11 @@ For example, the identifer for the allele example under :ref:`digest-serializati
 
 .. parsed-literal::
 
-    ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
+   ga4gh\:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH\_
 
 
 .. _plan-b:
-   
+
 Namespace Contingency Plan
 @@@@@@@@@@@@@@@@@@@@@@@@@@
 
@@ -275,4 +275,3 @@ All other aspects of the computed identifier scheme will remain intact.
 .. [Gibson] `Gibson Canonical JSON <http://gibson042.github.io/canonicaljson-spec/>`__
 .. [OLPC] `OLPC Canonical JSON <http://wiki.laptop.org/go/Canonical_JSON>`__
 .. [JCS] `JSON Canonicalization Scheme <https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05>`__
-

--- a/docs/source/impl-guide/computed_identifier.rst
+++ b/docs/source/impl-guide/computed_identifier.rst
@@ -133,6 +133,10 @@ The criteria for the digest serialization method was that it must be
 relatively easy and reliable to implement in any common computer
 language.
 
+.. _digest-serialization-example:
+
+**Example**
+
 .. code:: ipython3
 
     allele = models.Allele(location=models.SequenceLocation(

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -53,10 +53,9 @@ Primitive Concepts
 @@@@@@@@@@@@@@@@@@
 
 .. _b64udigest:
-.. _digest:
 
-_digest
-#######
+B64UDigest
+##########
 
 **Biological definition**
 
@@ -64,32 +63,29 @@ None.
 
 **Computational definition**
 
-A `base64url <https://tools.ietf.org/html/rfc4648#section-5>`_ encoded string
-referred to as a **B64UDigest**.
-
-The **B64UDigest** is further constrained to a
-`sha512t24u truncated digest <truncated-digest>`_ string that uniquely identifies
-the instance of the object concept with which it is associated.
-
-.. note:: *_digest* is a building block for creating globally unique identifiers.
-
+A string that is constrained to represent `base64url
+<https://tools.ietf.org/html/rfc4648#section-5>`_ encoded data.
 
 **Implementation guidance**
 
-* The _digest MUST be derived by :ref:`digest-serialization`.
-* _digests are case-sensitive.
-* Implementations MUST replace nested identifiable objects wit their corresponding
-  digests when constructing :ref:`computed-identifiers` for
-  VR objects (including sequences identifier *sequence_id*).
+* A ``B64UDigest`` is the encoding used for globally unique
+  identifiers. See :ref:`computed-identifiers` for details.
+* A ``B64UDigest`` is case-sensitive. Implementations MUST NOT alter
+  ``V64UDigest`` strings in any way.
+* In VR-Spec, the ``B64UDigest`` is primirily used to store
+  `sha512t24u truncated digest <truncated-digest>`_ values.
+* Implementations MUST replace nested identifiable objects with their
+  corresponding digests when constructing :doc:`computed-identifier`
+  for VR objects (including sequences identifier *sequence_id*).
 
 **Example**
 
 see :ref:`Digest Serialization Examples <digest-serialization-example>`
 
-.. _id:
+.. _curie:
 
-_id
-###
+CURIE
+#####
 
 **Biological definition**
 
@@ -97,19 +93,22 @@ None.
 
 **Computational definition**
 
-A `CURIE <https://www.w3.org/TR/curie/>`__ formatted string that uniquely identifies a
-specific instance of an object within a document.
-
+A `CURIE <https://www.w3.org/TR/curie/>`__ formatted string.  A CURIE
+string has the structure ``prefix``:``reference`` (W3C Terminology).
+ 
 **Implementation guidance**
 
-* This specification RECOMMENDS using a :ref:`computed-identifiers` for each *_id*.
+* CURIE-formatted identifiers are used as global identifiers of GA4GH
+  VR objects.  This specification RECOMMENDS using a
+  :ref:`computed-identifiers` to construct globally unique identifiers
+  for objects.  These identifiers are recommended for use within *and*
+  between systems.
+* CURIE-formatted identifiers are also used for references to data
+  outside the scope of this specification, such as reference
+  sequences.
 * When an appropriate namespace exists at `identifiers.org
   <http://identifiers.org/>`__, that namespace MUST be used verbatim.
 * Identifiers are case-sensitive.
-* The VR data schema permits any CURIE identifier to be used when
-  representing data.
-* Implementations MUST use ga4gh sequence identifiers when
-  constructing :ref:`computed-identifiers` for VR objects.
 
 **Example**
 
@@ -118,6 +117,9 @@ Identifiers for GRCh38 chromosome 19::
     ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
     refseq:NC_000019.10
     grch38:19
+
+See :ref:`identify` for examples of CURIE-based identifiers for VR
+objects.
 
 
 .. _residue:
@@ -350,11 +352,11 @@ named :ref:`Sequence`.
      - Limits
      - Description
    * - _digest
-     - :ref:`B64UDigest <b64udigest>`
+     - :ref:`b64udigest`
      - 0..1
      - The :ref:`truncated-digest` for the SequenceLocation.
    * - _id
-     - :ref:`CURIE <id>`
+     - :ref:`CURIE`
      - 0..1
      - Location Id; must be unique within document
    * - type
@@ -362,7 +364,7 @@ named :ref:`Sequence`.
      - 1..1
      - Location type; must be set to '**SequenceLocation**'
    * - sequence_id
-     - :ref:`CURIE <id>`
+     - :ref:`CURIE`
      - 1..1
      - An id mapping to the :ref:`computed-identifiers` of the external database Sequence containing the sequence to be located.
    * - interval
@@ -520,11 +522,11 @@ indels).
      - Limits
      - Description
    * - _digest
-     - :ref:`B64UDigest <b64udigest>`
+     - :ref:`b64udigest`
      - 0..1
      - The :ref:`truncated-digest` for the Allele Variation.
    * - _id
-     - :ref:`CURIE <id>`
+     - :ref:`CURIE`
      - 0..1
      - Variation Id; must be unique within document
    * - type
@@ -644,11 +646,11 @@ subclasses, but are still treated as variation.
      - Limits
      - Description
    * - _digest
-     - :ref:`B64UDigest <b64udigest>`
+     - :ref:`b64udigest`
      - 0..1
      - The :ref:`truncated-digest` for the Text Variation.
    * - _id
-     - :ref:`CURIE <id>`
+     - :ref:`CURIE`
      - 0..1
      - Variation Id; must be unique within document
    * - type

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -47,17 +47,16 @@ depend only on previously-defined terms.
 
 .. todo:: add note about _ prefix
 
-.. todo:: id attributes -> _digest, _id attributes
-
 ----
 
 Primitive Concepts
 @@@@@@@@@@@@@@@@@@
 
-.. _id:
+.. _b64udigest:
+.. _digest:
 
-Id
-##
+_digest
+#######
 
 **Biological definition**
 
@@ -65,19 +64,52 @@ None.
 
 **Computational definition**
 
-A `CURIE-formatted <curie-spec>`_ string that uniquely identifies a
+A `base64url <https://tools.ietf.org/html/rfc4648#section-5>`_ encoded string
+referred to as a **B64UDigest**.
+
+The **B64UDigest** is further constrained to a
+`sha512t24u truncated digest <truncated-digest>`_ string that uniquely identifies
+the instance of the object concept with which it is associated.
+
+.. note:: *_digest* is a building block for creating globally unique identifiers.
+
+
+**Implementation guidance**
+
+* The _digest MUST be derived by :ref:`digest-serialization`.
+* _digests are case-sensitive.
+* Implementations MUST replace nested identifiable objects wit their corresponding
+  digests when constructing :ref:`computed-identifiers` for
+  VR objects (including sequences identifier *sequence_id*).
+
+**Example**
+
+see :ref:`Digest Serialization Examples <digest-serialization-example>`
+
+.. _id:
+
+_id
+###
+
+**Biological definition**
+
+None.
+
+**Computational definition**
+
+A `CURIE <curie-spec>`__ formatted string that uniquely identifies a
 specific instance of an object within a document.
 
 **Implementation guidance**
 
-* This specification RECOMMENDS using a :ref:`computed-identifiers` for each id.
+* This specification RECOMMENDS using a :ref:`computed-identifiers` for each *_id*.
 * When an appropriate namespace exists at `identifiers.org
   <http://identifiers.org/>`__, that namespace MUST be used verbatim.
 * Identifiers are case-sensitive.
 * The VR data schema permits any CURIE identifier to be used when
   representing data.
 * Implementations MUST use ga4gh sequence identifiers when
-  constructing :ref:`computed identifiers <computed-identifiers>` for VR objects.
+  constructing :ref:`computed-identifiers` for VR objects.
 
 **Example**
 
@@ -165,20 +197,17 @@ None.
 
 The *Interval* abstract class defines a range on a :ref:`sequence`,
 possibly with length zero, and specified using
-:ref:`interbase-coordinates`. An Interval may be a
+:ref:`interbase-coordinates-design`. An Interval may be a
 :ref:`SimpleInterval` with a single start and end coordinate.
 :ref:`Future Location and Interval types <planned-locations>` will
 enable other methods for describing where :ref:`variation` occurs. Any
 of these may be used as the Interval for Location.
 
-
-.. _interbase-coordinates:
-
-.. sidebar:: VR Uses Interbase Coordinates 
+.. sidebar:: VR Uses Interbase Coordinates
 
    **GA4GH VR uses interbase coordinates when referring to spans of
    sequence.**
-   
+
    Interbase coordinates refer to the zero-width points before and
    after :ref:`residues <Residue>`. An interval of interbase
    coordinates permits referring to any span, including an empty span,
@@ -198,13 +227,28 @@ An :ref:`Interval` with a single start and end coordinate.
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
+   :widths: auto
 
-   type, string, required, Interval type; must be set to 'SimpleInterval'
-   start, uint64, required, start position
-   end, uint64, required, end position
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - Interval type; must be set to '**SimpleInterval**'
+   * - start
+     - uint64
+     - 1..1
+     - start position
+   * - end
+     - uint64
+     - 1..1
+     - end position
 
 **Implementation guidance**
 
@@ -295,15 +339,36 @@ named :ref:`Sequence`.
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
-   :widths: 12, 9, 10, 30
+   :widths: auto
 
-   id, :ref:`Id`, optional, Location Id; must be unique within document
-   type, string, required, Location type; must be set to 'SequenceLocation'
-   sequence_id, :ref:`Id`, required, An id mapping to the Identifier of the external database Sequence
-   interval, :ref:`Interval`, required, Position of feature on reference sequence specified by sequence_id.
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the SequenceLocation.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Location Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Location type; must be set to '**SequenceLocation**'
+   * - sequence_id
+     - :ref:`CURIE <id>`
+     - 1..1
+     - An id mapping to the :ref:`computed-identifiers` of the external database Sequence containing the sequence to be located.
+   * - interval
+     - :ref:`Interval`
+     - 1..1
+     - Position of feature on reference sequence specified by sequence_id.
 
 **Implementation guidance**
 
@@ -336,7 +401,7 @@ named :ref:`Sequence`.
       "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
       "type": "SequenceLocation"
     }
-     
+
 
 State (Abstract Class)
 ######################
@@ -373,14 +438,24 @@ The *SequenceState* class specifically captures a :ref:`sequence` as a
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
-   :widths: 12, 9, 10, 30
+   :widths: auto
 
-   id, :ref:`Id`, optional, State Id; must be unique within document
-   type, string, required, State type; must be set to 'SequenceState'
-   sequence, :ref:`Sequence`, required, The sequence that is to be used as the state for other types.
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - State type; must be set to '**SequenceState**'
+   * - sequence
+     - string
+     - 1..1
+     - The string of sequence residues that is to be used as the state for other types.
 
 **Example**
 
@@ -434,15 +509,36 @@ indels).
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
-   :widths: 12, 9, 10, 30
+   :widths: auto
 
-   id, :ref:`Id`, optional, Variation Id; must be unique within document
-   type, string, required, Variation type; must be set to 'Allele'
-   location, :ref:`Location`, required, Where Allele is located
-   state, :ref:`State`, required, State at location
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the Allele Variation.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Variation Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Variation type; must be set to '**Allele**'
+   * - location
+     - :ref:`Location`
+     - 1..1
+     - Where Allele is located
+   * - state
+     - :ref:`State`
+     - 1..1
+     - State at location
 
 **Implementation guidance**
 
@@ -537,14 +633,32 @@ subclasses, but are still treated as variation.
 
 **Information model**
 
-.. csv-table::
-   :header: Field, Type, Label, Description
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
    :align: left
-   :widths: 12, 9, 10, 30
+   :widths: auto
 
-   id, :ref:`Id`, optional, Variation Id; must be unique within document
-   type, string, required, Variation type; must be set to 'Text'
-   definition, string, required, The textual variation representation not parsable by other subclasses of Variation.
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _digest
+     - :ref:`B64UDigest <b64udigest>`
+     - 0..1
+     - The :ref:`truncated-digest` for the Text Variation.
+   * - _id
+     - :ref:`CURIE <id>`
+     - 0..1
+     - Variation Id; must be unique within document
+   * - type
+     - string
+     - 1..1
+     - Variation type; must be set to '**Text**'
+   * - definition
+     - string
+     - 1..1
+     - The textual variation representation not parsable by other subclasses of Variation.
 
 **Implementation guidance**
 
@@ -564,6 +678,8 @@ subclasses, but are still treated as variation.
   representation.
 
 **Example**
+
+.. parsed-literal::
 
     {
       "definition": "APOE loss",

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -97,7 +97,7 @@ None.
 
 **Computational definition**
 
-A `CURIE <curie-spec>`__ formatted string that uniquely identifies a
+A `CURIE <https://www.w3.org/TR/curie/>`__ formatted string that uniquely identifies a
 specific instance of an object within a document.
 
 **Implementation guidance**

--- a/schema/vr.json
+++ b/schema/vr.json
@@ -73,38 +73,6 @@
             }
          ]
       },
-      "NestedInterval": {
-         "additionalProperties": false,
-         "example": {
-            "inner": {
-               "end": 30,
-               "start": 20,
-               "type": "SimpleInterval"
-            },
-            "outer": {
-               "end": 40,
-               "start": 10,
-               "type": "SimpleInterval"
-            },
-            "type": "NestedInterval"
-         },
-         "properties": {
-            "inner": {
-               "$ref": "#/definitions/SimpleInterval"
-            },
-            "outer": {
-               "$ref": "#/definitions/SimpleInterval"
-            },
-            "type": {
-               "default": "NestedInterval",
-               "enum": [
-                  "NestedInterval"
-               ],
-               "type": "string"
-            }
-         },
-         "type": "object"
-      },
       "SequenceLocation": {
          "additionalProperties": false,
          "properties": {

--- a/schema/vr.json
+++ b/schema/vr.json
@@ -9,7 +9,7 @@
                "$ref": "#/definitions/B64UDigest"
             },
             "_id": {
-               "$ref": "#/definitions/Id"
+               "$ref": "#/definitions/CURIE"
             },
             "location": {
                "$ref": "#/definitions/Location"
@@ -29,21 +29,21 @@
       },
       "B64UDigest": {
          "additionalProperties": false,
-         "description": "A [base64url](https://tools.ietf.org/html/rfc4648#section-5) encoded string. See the [VR Specification](https://vr-spec.readthedocs.io) for details.",
+         "description": "A digest encoded using the [base64url](https://tools.ietf.org/html/rfc4648#section-5) character set.",
          "example": "_ABC-abc-123_",
          "pattern": "^[-_A-Za-z0-9]+$",
+         "type": "string"
+      },
+      "CURIE": {
+         "additionalProperties": false,
+         "description": "A string that refers to an object uniquely.  The lifetime and scope of an id is defined by the sender.\nVR does not impose any contraints on strings used as ids in messages. However, to maximize sharability of data, the VR Specification RECOMMENDS that implementations use [W3C Compact URI (CURIE)](https://www.w3.org/TR/curie/) syntax.\nString CURIEs are represented as `prefix`:`reference` (W3C terminology), but often referred to as `namespace`:`accession` or `namespace`:`local id` colloquially.\nThe VR specification also RECOMMENDS that `prefix` be defined in identifiers.org.\nThe `reference` component is an unconstrained string.\nA CURIE is a URI.  URIs may *locate* objects (i.e., specify where to retrieve them) or *name* objects conceptually.  VR uses CURIEs primarily as a naming mechanism.\nImplementations MAY provide CURIE resolution mechanisms for prefixes to make these objects locatable.\nUsing internal ids in public messages is strongly discouraged.",
+         "example": "ga4gh:GA.01234abcde",
+         "pattern": "^\\w[^:]+:.+$",
          "type": "string"
       },
       "DateTime": {
          "additionalProperties": false,
          "format": "date-time",
-         "type": "string"
-      },
-      "Id": {
-         "additionalProperties": false,
-         "description": "A string that refers to an object uniquely.  The lifetime and scope of an id is defined by the sender.\nVR does not impose any contraints on strings used as ids in messages. However, to maximize sharability of data, the VR Specification RECOMMENDS that implementations use [W3C Compact URI (CURIE)](https://www.w3.org/TR/curie/) syntax.\nString CURIEs are represented as `prefix`:`reference` (W3C terminology), but often referred to as `namespace`:`accession` or `namespace`:`local id` colloquially.\nThe VR specification also RECOMMENDS that `prefix` be defined in identifiers.org.\nThe `reference` component is an unconstrained string.\nA CURIE is a URI.  URIs may *locate* objects (i.e., specify where to retrieve them) or *name* objects conceptually.  VR uses CURIEs primarily as a naming mechanism.\nImplementations MAY provide CURIE resolution mechanisms for prefixes to make these objects locatable.\nUsing internal ids in public messages is strongly discouraged.",
-         "example": "ga4gh:GA.01234abcde",
-         "pattern": "^\\w[^:]+:.+$",
          "type": "string"
       },
       "Interval": {
@@ -55,9 +55,6 @@
          "oneOf": [
             {
                "$ref": "#/definitions/SimpleInterval"
-            },
-            {
-               "$ref": "#/definitions/NestedInterval"
             }
          ]
       },
@@ -80,13 +77,13 @@
                "$ref": "#/definitions/B64UDigest"
             },
             "_id": {
-               "$ref": "#/definitions/Id"
+               "$ref": "#/definitions/CURIE"
             },
             "interval": {
                "$ref": "#/definitions/Interval"
             },
             "sequence_id": {
-               "$ref": "#/definitions/Id"
+               "$ref": "#/definitions/CURIE"
             },
             "type": {
                "default": "SequenceLocation",
@@ -167,7 +164,7 @@
                "$ref": "#/definitions/B64UDigest"
             },
             "_id": {
-               "$ref": "#/definitions/Id"
+               "$ref": "#/definitions/CURIE"
             },
             "definition": {
                "description": "An textual representation of variation intended to capture variation descriptions that cannot be parsed, but still treated as variation.",

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -71,7 +71,7 @@ definitions:
       - $ref: "#/definitions/SequenceLocation"
     discriminator:
       propertyName: type
-  
+
   SequenceLocation:
     additionalProperties: false
     type: object
@@ -93,7 +93,6 @@ definitions:
   ############################################################################
   # Interval
   # * SimpleInterval
-  # * NestedInterval
 
   Interval:
     additionalProperties: false
@@ -110,7 +109,6 @@ definitions:
       zero".
     oneOf:
       - $ref: '#/definitions/SimpleInterval'
-      - $ref: '#/definitions/NestedInterval'
     discriminator:
       propertyName: type
 
@@ -136,29 +134,6 @@ definitions:
       start: 11
       end: 22
 
-  NestedInterval:
-    additionalProperties: false
-    type: object
-    properties:
-      type:
-        type: string
-        enum: [NestedInterval]
-        default: NestedInterval
-      inner:
-        $ref: '#/definitions/SimpleInterval'
-      outer:
-        $ref: '#/definitions/SimpleInterval'
-    example:
-      type: NestedInterval
-      inner:
-        type: SimpleInterval
-        start: 20
-        end: 30
-      outer:
-        type: SimpleInterval
-        start: 10
-        end: 40
-
 
   ############################################################################
   # States
@@ -166,7 +141,7 @@ definitions:
   State:
     oneOf:
       - $ref: "#/definitions/SequenceState"
-  
+
   SequenceState:
     additionalProperties: false
     type: object
@@ -194,7 +169,7 @@ definitions:
     additionalProperties: false
     type: string
     format: "date-time"
-  
+
   B64UDigest:
     additionalProperties: false
     description: >-
@@ -204,7 +179,7 @@ definitions:
 
     type: string
     pattern: '^[-_A-Za-z0-9]+$'
-    example: "_ABC-abc-123_"      
+    example: "_ABC-abc-123_"
 
   CURIE:
     additionalProperties: false
@@ -237,4 +212,4 @@ definitions:
 
     type: string
     pattern: '^\w[^:]+:.+$'
-    example: "ga4gh:GA.01234abcde"      
+    example: "ga4gh:GA.01234abcde"

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -173,9 +173,9 @@ definitions:
   B64UDigest:
     additionalProperties: false
     description: >-
-      A [base64url](https://tools.ietf.org/html/rfc4648#section-5)
-      encoded string. See the [VR
-      Specification](https://vr-spec.readthedocs.io) for details.
+      A digest encoded using the
+      [base64url](https://tools.ietf.org/html/rfc4648#section-5)
+      character set.
 
     type: string
     pattern: '^[-_A-Za-z0-9]+$'


### PR DESCRIPTION
… also applied to future-plans. added B64UDigest & CURIE refs throughout.

closes #145 

@reece or @ahwagner please review/edit the _digest and _id sections at the beginning of the Primitive Concepts section. I took a shot at writing them up and used them as substitutes for the B64UDigest and CURIE data types in the subsequent info model tables for the composite concepts.

