### PR TITLE
#173: Allow Allele.location to be a CURIE

### DIFF
--- a/schema/vr.json
+++ b/schema/vr.json
@@ -9,7 +9,14 @@
                "$ref": "#/definitions/CURIE"
             },
             "location": {
-               "$ref": "#/definitions/Location"
+               "oneOf": [
+                  {
+                     "$ref": "#/definitions/Location"
+                  },
+                  {
+                     "$ref": "#/definitions/CURIE"
+                  }
+               ]
             },
             "state": {
                "$ref": "#/definitions/State"

--- a/schema/vr.json
+++ b/schema/vr.json
@@ -11,10 +11,10 @@
             "location": {
                "oneOf": [
                   {
-                     "$ref": "#/definitions/Location"
+                     "$ref": "#/definitions/CURIE"
                   },
                   {
-                     "$ref": "#/definitions/CURIE"
+                     "$ref": "#/definitions/Location"
                   }
                ]
             },

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -62,8 +62,8 @@ definitions:
         $ref: "#/definitions/CURIE"
       location:
         oneOf:
-          - $ref: "#/definitions/Location"
           - $ref: "#/definitions/CURIE"
+          - $ref: "#/definitions/Location"
       state:
         $ref: "#/definitions/State"
 

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -61,7 +61,9 @@ definitions:
       _id:
         $ref: "#/definitions/CURIE"
       location:
-        $ref: "#/definitions/Location"
+        oneOf:
+          - $ref: "#/definitions/Location"
+          - $ref: "#/definitions/CURIE"
       state:
         $ref: "#/definitions/State"
 

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -73,3 +73,15 @@ Allele:
       ga4gh_digest: EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
       ga4gh_identify: ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
       ga4gh_serialize: '{"location":"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'
+
+  -
+    in:
+      location: ga4gh:VSL.u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx
+      state:
+        sequence: T
+        type: SequenceState
+      type: Allele
+    out:
+      ga4gh_digest: EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
+      ga4gh_identify: ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
+      ga4gh_serialize: '{"location":"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'


### PR DESCRIPTION
This minor change allows a Allele.location property to be an object (as-is) or a CURIE (new). See #173 for elaboration.

vr-python has minor updates to facilitate this change, which I'll commit separately.