### PR TITLE
Remove Haplotype Location

### DIFF
--- a/schema/vr.json
+++ b/schema/vr.json
@@ -81,17 +81,6 @@
             "_id": {
                "$ref": "#/definitions/CURIE"
             },
-            "location": {
-               "default": null,
-               "oneOf": [
-                  {
-                     "$ref": "#/definitions/CURIE"
-                  },
-                  {
-                     "$ref": "#/definitions/Location"
-                  }
-               ]
-            },
             "members": {
                "items": {
                   "oneOf": [

--- a/schema/vr.yaml
+++ b/schema/vr.yaml
@@ -218,11 +218,6 @@ definitions:
         type: string
         enum: ["Haplotype"]
         default: "Haplotype"
-      location:
-        oneOf:
-          - $ref: "#/definitions/CURIE"
-          - $ref: "#/definitions/Location"
-        default: null
       members:
         type: array
         minItems: 1


### PR DESCRIPTION
We have decided to wait on the use of `Location` in `Haplotype` until consensus is reached on implementation details. This is a forward-compatible decision that will unblock other efforts.

While our documentation was updated to reflect this change, the schema itself was not. This PR makes the corresponding change to the schema.