### PR TITLE
#193: ref allele normalization

### DIFF
--- a/docs/source/appendices/design_decisions.rst
+++ b/docs/source/appendices/design_decisions.rst
@@ -50,12 +50,11 @@ consequence is better associated with an allele than with a variant.
 Alleles are Fully Justified
 @@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-In order to standardize the presentation of sequence variation, computed ids from
-VRS require that Alleles be fully justified from the description
-of the NCBI `Variant Overprecision Correction Algorithm (VOCA)`_. Furthermore,
-normalization rules must be identical for all sequence types; although this
-need not be a strict requirement, there is no reason to normalize using
-different strategies based on sequence type.
+In order to standardize the representation of sequence variation,
+Alleles SHOULD be fully justified from the description of the NCBI
+`Variant Overprecision Correction Algorithm (VOCA)`_. Furthermore,
+normalization rules are identical for all sequence types (DNA, RNA,
+and protein). 
 
 The choice of algorithm was relatively straightforward: VOCA is
 published, easily understood, easily implemented, and

--- a/docs/source/appendices/design_decisions.rst
+++ b/docs/source/appendices/design_decisions.rst
@@ -45,6 +45,46 @@ when referring to an unchanged residue. In some cases, such "variants"
 are even associated with allele frequencies. Similarly, a predicted
 consequence is better associated with an allele than with a variant.
 
+.. _should-normalize:
+
+Implementations should normalize
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+VRS STRONGLY RECOMMENDS that Alleles be :ref:`normalized
+<normalization>` when generating :ref:`computed identifiers
+<computed-identifiers>`. The rationale for recommending, rather than
+requiring, normalization is grounded in dual views of Allele objects
+with distinct interpretations:
+
+* Allele as minimal representation of a change in sequence. In this
+  view, normalization is a process that makes the representation
+  minimal and unambiguous.
+
+* Allele as an assertion of state. In this view, it is reasonable to
+  want to assert state that may include (or be composed entirely of)
+  reference bases, for which the normalization process would alter the
+  intent.
+
+Although this rationale applies only to Alleles, it may have have
+parallels with other VRS types. In addition, it is desirable for all
+VRS types to be treated similarly.
+
+Furthermore, if normalization were required in order to generate
+:ref:`computed-identifiers`, but did not apply to certain instances of
+VRS Variation, implementations would likely require secondary
+identifier mechanisms, which would undermine the intent of a global
+computed identifier.
+
+The primary downside of not requiring normalization is that Variation
+objects might be written in non-canonical forms, thereby creating
+unintended degeneracy.
+
+Therefore, normalization of all VRS Variation classes is optional in
+order to support the view of Allele as an assertion of state on a
+sequence.
+
+
+
 .. _fully-justified:
 
 Alleles are Fully Justified

--- a/docs/source/impl-guide/computed_identifiers.rst
+++ b/docs/source/impl-guide/computed_identifiers.rst
@@ -3,19 +3,19 @@
 Computed Identifiers
 !!!!!!!!!!!!!!!!!!!!
 
-VRS provides an algorithmic solution to deterministically
-generate a globally unique identifier from a VRS object itself. All
-valid implementations of the VRS Computed Identifier will generate the
-same identifier when the objects are identical, and will generate
-different identifiers when they are not. The VRS Computed Digest
-algorithm obviates centralized registration services, allows
-computational pipelines to generate "private" ids efficiently, and
-makes it easier for distributed groups to share data.
+VRS provides an algorithmic solution to deterministically generate a
+globally unique identifier from a VRS object itself. All valid
+implementations of the VRS Computed Identifier will generate the same
+identifier when the objects are identical, and will generate different
+identifiers when they are not. The VRS Computed Digest algorithm
+obviates centralized registration services, allows computational
+pipelines to generate "private" ids efficiently, and makes it easier
+for distributed groups to share data.
 
 A VRS Computed Identifier for a VRS concept is computed as follows:
 
-* :ref:`Normalize <normalization>` the object.  Normalization formally
-  applies to all VRS classes.
+* The object SHOULD be :ref:`normalized <normalization>`.
+  Normalization formally applies to all VRS classes.
 
 * Generate binary data to digest. If the object is a :ref:`sequence`
   string, encode it using UTF-8.  Otherwise, serialize the object
@@ -25,9 +25,17 @@ A VRS Computed Identifier for a VRS concept is computed as follows:
 
 * :ref:`Construct an identifier <identify>` based on the digest and object type.
 
+.. important:: Normalizing objects is STRONGLY RECOMMENDED for
+               interoperability. While normalization is not strictly
+               required, automated validation mechanisms are
+               anticipated that will likely disqualify Variation that
+               is not normalized. See :ref:`should-normalize` for
+               a rationale.
+
 The following diagram depicts the operations necessary to generate a
 computed identifier.  These operations are described in detail in the
 subsequent sections.
+
 
 .. _ser-dig-id:
 .. figure:: ../images/id-dig-ser.png

--- a/docs/source/impl-guide/computed_identifiers.rst
+++ b/docs/source/impl-guide/computed_identifiers.rst
@@ -14,7 +14,8 @@ makes it easier for distributed groups to share data.
 
 A VRS Computed Identifier for a VRS concept is computed as follows:
 
-* If the object is an :ref:`allele`, :ref:`normalize <normalization>` it.
+* :ref:`Normalize <normalization>` the object.  Normalization formally
+  applies to all VRS classes.
 
 * Generate binary data to digest. If the object is a :ref:`sequence`
   string, encode it using UTF-8.  Otherwise, serialize the object

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -11,7 +11,7 @@ VRS normalization minimizes a class of ambiguity that impedes
 comparison of variation across systems.
 
 Implementations MUST provide a normalize function that accepts any
-Variation object and returns a normalized Variation.  Guidelines for
+Variation object and returns a normalized Variation object.  Guidelines for
 these functions are below.
 
 

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -25,8 +25,8 @@ General Normalization Rules
 * Object types that do not have explicit VRS normalization rules below
   are returned as-is.  That is, all types of Variation MUST be
   supported, even if such objects are unchanged.
-* VRS normalization functions are idempotent: Normalizing a normalized
-  Variation object returns an object with the same data.
+* VRS normalization functions are idempotent: Normalizing a previously-normalized
+  object returns the same object.
 * VRS normalization functions are not necessarily homomorphic: That
   is, the input and output objects may be of different types.
 

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -9,7 +9,7 @@ Normalization eliminates a class of ambiguity that impedes comparison
 of variation across systems.
 
 In the sequencing community, "normalization" refers to the process of
-converting a given sequence variant into a canonincal form, typically
+converting a given sequence variant into a canonical form, typically
 by left- or right-shuffling insertion/deletion variants.  VRS
 normalization extends this concept to all classes of VRS Variation
 objects.

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -21,7 +21,7 @@ General Normalization Rules
 * VRS normalization functions are homomorphic: That is, the input and
   output objects are always of the same `type`.
 * Object types that do not have VRS normalization rules are returned
-  as-is.  That is, all types of Variation MUST be supported, even if
+  as-is.  That is, all types of VRS objects MUST be supported, even if
   such objects are unchanged.
 * VRS normalization functions are idempotent: Normalizing a normalized
   Variation object returns an object with the same data.

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -25,8 +25,8 @@ General Normalization Rules
 * Object types that do not have explicit VRS normalization rules below
   are returned as-is.  That is, all types of Variation MUST be
   supported, even if such objects are unchanged.
-* VRS normalization functions are idempotent: Normalizing a previously-normalized
-  object returns the same object.
+* VRS normalization functions are idempotent: Normalizing a
+  previously-normalized object returns an equivalent object.
 * VRS normalization functions are not necessarily homomorphic: That
   is, the input and output objects may be of different types.
 

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -47,8 +47,8 @@ representation that may be readily compared with other alleles.
 
 VRS RECOMMENDS that Alleles at precise locations are normalized to a
 fully justified form unless there is a compelling reason to do
-otherwise.  In addition, Alleles MUST be normalized in order to
-generate :ref:`computed-identifiers`.
+otherwise.  Alleles SHOULD be normalized in order to generate
+:ref:`computed-identifiers`.
 
 The process for fully justifying an Allele is outlined below.
 

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -74,7 +74,7 @@ The process for fully justifying an Allele is outlined below.
    Allele.  Construct and return a new Allele with the current
    `start`, `end`, and `alternate allele sequence`.
 
-   NOTE: The remainings case is that exactly one of `reference allele
+   NOTE: The remaining cases are that exactly one of `reference allele
    sequence` or `alternate allele sequence` is empty.  If `reference
    allele sequence` is empty, the Allele represents an insertion in
    the reference.  If `alternate allele sequence` is empty, the Allele

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -3,28 +3,33 @@
 Normalization
 !!!!!!!!!!!!!
 
-In VRS, "normalization" refers to the process of converting a given
-variation representation into a canonincal form.  Left- and
-right-shuffling are examples of normalization for sequence variants.
-VRS extends this concept to apply to all classes of VRS Variation.
-VRS normalization minimizes a class of ambiguity that impedes
-comparison of variation across systems.
+In VRS, "normalization" refers to the process of rewriting an
+ambiguous variation representation of variation into a canonical form.
+Normalization eliminates a class of ambiguity that impedes comparison
+of variation across systems.
 
-Implementations MUST provide a normalize function that accepts any
-Variation object and returns a normalized Variation object.  Guidelines for
+In the sequencing community, "normalization" refers to the process of
+converting a given sequence variant into a canonincal form, typically
+by left- or right-shuffling insertion/deletion variants.  VRS
+normalization extends this concept to all classes of VRS Variation
+objects.
+
+Implementations MUST provide a normalize function that accepts *any*
+Variation object and returns a normalized Variation.  Guidelines for
 these functions are below.
 
 
 General Normalization Rules
 @@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-* VRS normalization functions are homomorphic: That is, the input and
-  output objects are always of the same `type`.
-* Object types that do not have VRS normalization rules are returned
-  as-is.  That is, all types of VRS objects MUST be supported, even if
-  such objects are unchanged.
+* Object types that do not have explicit VRS normalization rules below
+  are returned as-is.  That is, all types of Variation MUST be
+  supported, even if such objects are unchanged.
 * VRS normalization functions are idempotent: Normalizing a normalized
   Variation object returns an object with the same data.
+* VRS normalization functions are not necessarily homomorphic: That
+  is, the input and output objects may be of different types.
+
 
 
 Allele Normalization

--- a/docs/source/impl-guide/normalization.rst
+++ b/docs/source/impl-guide/normalization.rst
@@ -3,22 +3,52 @@
 Normalization
 !!!!!!!!!!!!!
 
-Certain insertion or deletion alleles may be represented ambiguously
-when using conventional sequence normalization, resulting in
-significant challenges when comparing such alleles.
+In VRS, "normalization" refers to the process of converting a given
+variation representation into a canonincal form.  Left- and
+right-shuffling are examples of normalization for sequence variants.
+VRS extends this concept to apply to all classes of VRS Variation.
+VRS normalization minimizes a class of ambiguity that impedes
+comparison of variation across systems.
 
-VRS describes a "fully-justified" normalization algorithm
-inspired by NCBI's Variant Overprecision Correction Algorithm [1]_.
+Implementations MUST provide a normalize function that accepts any
+Variation object and returns a normalized Variation.  Guidelines for
+these functions are below.
+
+
+General Normalization Rules
+@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+* VRS normalization functions are homomorphic: That is, the input and
+  output objects are always of the same `type`.
+* Object types that do not have VRS normalization rules are returned
+  as-is.  That is, all types of Variation MUST be supported, even if
+  such objects are unchanged.
+* VRS normalization functions are idempotent: Normalizing a normalized
+  Variation object returns an object with the same data.
+
+
+Allele Normalization
+@@@@@@@@@@@@@@@@@@@@
+
+Certain insertion or deletion alleles may have ambiguous
+representations when using conventional sequence normalization,
+resulting in significant challenges when comparing such alleles.
+
+VRS uses a "fully-justified" normalization algorithm inspired by
+NCBI's Variant Overprecision Correction Algorithm [1]_.
 Fully-justified normalization expands such ambiguous representation
 over the entire region of ambiguity, resulting in an *unambiguous*
 representation that may be readily compared with other alleles.
 
-VRS RECOMMENDS that Alleles at precise locations are
-normalized to a fully justified form unless there is a compelling
-reason to do otherwise.
+VRS RECOMMENDS that Alleles at precise locations are normalized to a
+fully justified form unless there is a compelling reason to do
+otherwise.  In addition, Alleles MUST be normalized in order to
+generate :ref:`computed-identifiers`.
 
 The process for fully justifying two alleles (reference sequence and
 alternate sequence) at an interval is outlined below.
+
+.. NOTE:: Align step numbers here and example table below
 
 1. Trim sequences:
 


### PR DESCRIPTION
This PR addresses shortcomings of the current description of normalization. As stated in [this comment on #193](https://github.com/ga4gh/vr-spec/issues/193#issuecomment-660556914), the goals of this PR are:

* Reserve the word "normalization" to mean the canonicalization process for all Variation classes.
* Require normalization prior to creating a computed identifier for all Variation classes.
* Modify current Allele normalization to handle ref agree, as follows:
  * In §2. Condition, add "If the reference and alternate alleles are empty, return the input location and alleles."

The majority of the changes are rendered in https://vr-spec.readthedocs.io/en/193-ref-allele-normalization/impl-guide/normalization.html. 

https://vr-spec.readthedocs.io/en/193-ref-allele-normalization/impl-guide/computed_identifiers.html has a minor change to require normalization for all objects.

