### PR TITLE
Patch version 1.1.1

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -22,6 +22,13 @@ Releases
 1.1
 @@@
 
+1.1.1
+#####
+This patch version makes the following corrections:
+
+  * Remove erroneous bracket notation after CURIE from the `locations` attribute
+    in the :ref:`Allele` information model.
+
 1.1.0
 #####
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -722,7 +722,7 @@ sequence at a :ref:`Location <Location>`.
      - 1..1
      - MUST be "Allele"
    * - location
-     - :ref:`Location` | :ref:`CURIE`\[]
+     - :ref:`Location` | :ref:`CURIE`
      - 1..1
      - Where Allele is located
    * - state


### PR DESCRIPTION
Changes:
- fix typo in Allele information model

Additional changes for the 1.1.1 patch should be added to the `1.1.1-patch` branch prior to merging this PR.